### PR TITLE
feat: expose `FilForwarder` metadata in adapter

### DIFF
--- a/examples/demo/src/components/forward.tsx
+++ b/examples/demo/src/components/forward.tsx
@@ -6,8 +6,8 @@ import * as Address from 'iso-filecoin/address'
 import { Token } from 'iso-filecoin/token'
 import { useForm, type SubmitHandler } from 'react-hook-form'
 import { useContractWrite } from 'wagmi'
-import { abi } from '../fil-forwarder.js'
 import { useFilsnapContext } from '../hooks/filsnap.js'
+import { filForwarderMetadata } from 'filsnap-adapter'
 
 interface Inputs {
   recipient: string
@@ -20,8 +20,8 @@ interface Inputs {
 function Forward() {
   const { account } = useFilsnapContext()
   const { data, isLoading, isSuccess, error, write } = useContractWrite({
-    address: '0x2B3ef6906429b580b7b2080de5CA893BC282c225',
-    abi,
+    address: filForwarderMetadata.contractAddress,
+    abi: filForwarderMetadata.abi,
     functionName: 'forward',
     value: 0n,
   })

--- a/packages/adapter/src/filforwarder-metadata.ts
+++ b/packages/adapter/src/filforwarder-metadata.ts
@@ -1,4 +1,4 @@
-export const abi = /** @type {const} */ ([
+const abi = [
   {
     inputs: [
       {
@@ -76,4 +76,22 @@ export const abi = /** @type {const} */ ([
     stateMutability: 'payable',
     type: 'function',
   },
-])
+]
+
+const contractAddress: `0x${string}` =
+  '0x2B3ef6906429b580b7b2080de5CA893BC282c225'
+
+const chainIds = {
+  filecoinMainnet: 314,
+  filecoinCalibrationTestnet: 314_159,
+}
+
+// FEVM FilForwarder contract metadata
+// Contract source: https://github.com/FILCAT/FilForwarder
+export const filForwarderMetadata = {
+  abi,
+  // The contract address is the same on all chains where the contract is deployed
+  contractAddress,
+  // The Ethereum chain ids where the contract is deployed
+  chainIds,
+}

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -1,3 +1,4 @@
 export { FilsnapAdapter } from './snap'
+export { filForwarderMetadata } from './filforwarder-metadata'
 
 export type { SnapConfig, AccountInfo } from 'filsnap'

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/filecoin-project/filsnap.git"
   },
   "source": {
-    "shasum": "tyJztEVhbticwDWbe6rN1ESFDMtz/jyrfAD0ovISqgo=",
+    "shasum": "A3iZwXzHmYbIDCPkBJ4OfiEMabYvimV54XNeqtrstNU=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
# Description

This is a small change to expose the FEVM `FilForwarder` metadata in the adapter.

## Link to issue

#20 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change that adds functionality)
- [x] This change requires a documentation update
- [x] Comments have been added/updated
