### PR TITLE
docs: add FilForwarder Viem example

### DIFF
--- a/examples/fil-forwarder-viem/README.md
+++ b/examples/fil-forwarder-viem/README.md
@@ -1,0 +1,14 @@
+# FilForwarder Viem Example
+
+This example shows how to call the
+[FilForwarder](https://github.com/FILCAT/FilForwarder/tree/main) contract with
+[Viem](https://viem.sh) to transfer FIL from a 0x address to an f1/t1 address.
+
+## Run locally
+
+From this directory:
+
+```bash
+pnpm install
+pnpm dev
+```

--- a/examples/fil-forwarder-viem/index.html
+++ b/examples/fil-forwarder-viem/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <meta name="theme-color" content="#484A65">
+        <meta name="description" content="Demo to transfer FIL from 0x address to f1 address with viem">
+        <title>Filsnap Demo</title>
+        
+        <!-- Based on https://www.quackit.com/css/flexbox/tutorial/align_form_elements_with_flexbox.cfm -->
+        <style>
+            .wrapper {
+                background-color: whitesmoke;
+                list-style-type: none;
+                padding: 0;
+                border-radius: 3px;
+            }
+            .form-row {
+                display: flex;
+                justify-content: flex-end;
+                padding: .5em;
+            }
+            .form-row > label {
+                padding: .5em 1em .5em 0;
+                flex: 1;
+            }
+            .form-row > input {
+                flex: 2;
+            }
+            .form-row > input,
+            .form-row > button {
+                padding: .5em;
+            }
+            .form-row > button {
+                background: gray;
+                color: white;
+                border: 0;
+            }
+            @media screen and (min-width: 768px) {
+                .form-row > input {
+                    flex: 3;
+                }
+            }
+            @media screen and (min-width: 992px) {
+                .form-row > input {
+                    flex: 4;
+                }
+            }
+            @media screen and (min-width: 1200px) {
+                .form-row > input {
+                    flex: 5;
+                }
+            }
+            #submit-button:disabled {
+                pointer-events: none;
+                background-color: #edf1f2;
+            }
+        </style>
+    </head>
+    <body>
+    <h1>Transfer FIL from 0x to f1 address</h1>
+    <form id="transfer-form">
+        <ul class="wrapper">
+            <li class="form-row">
+                    <label for="amount">Amount:</label>
+                    <input type="text" id="amount" name="amount" placeholder="Enter FIL amount" />
+            </li>
+            <li class="form-row">
+                    <label for="recipient">Recipient:</label>
+                    <input type="text" id="recipient" name="recipient" placeholder="Enter the recepient's f1/t1 address" />
+            </li>
+            <li class="form-row">
+                    <button type="submit" id="submit-button">Transfer</button>
+            </li>
+            <li class="form-row" id="tx-link">
+            </li>
+        </ul>
+    </form>
+
+    <script type="module" src="/src/main.ts"></script>
+    </body>
+</html>

--- a/examples/fil-forwarder-viem/package.json
+++ b/examples/fil-forwarder-viem/package.json
@@ -1,0 +1,95 @@
+{
+  "name": "demo",
+  "version": "1.0.0",
+  "description": "",
+  "author": "Hugo Dias <hugomrdias@gmail.com> (hugodias.me)",
+  "main": "src/main.jsx",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "lint": "tsc --build && eslint '**/*.{js,jsx,ts,tsx}' && prettier --check '**/*.{js,jsx,ts,tsx,yml,json}' --ignore-path ../../.gitignore",
+    "build": "wireit",
+    "dev": "wireit",
+    "serve": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "command": "vite build --force",
+      "dependencies": [
+        "../../packages/adapter:build"
+      ],
+      "clean": true,
+      "files": [
+        "index.html",
+        "src/**/*.{jsx,js,ts,tsx,css}",
+        "vite.config.js"
+      ],
+      "output": [
+        "dist/**/*.{html,js,css}"
+      ]
+    },
+    "serve": {
+      "command": "vite preview --port 3000",
+      "dependencies": [
+        "build"
+      ],
+      "service": true
+    },
+    "dev": {
+      "command": "vite --force",
+      "dependencies": [
+        "../../packages/adapter:build"
+      ],
+      "service": true
+    }
+  },
+  "keywords": [],
+  "license": "MIT",
+  "dependencies": {
+    "filsnap-adapter": "workspace:^",
+    "iso-base": "^1.1.1",
+    "iso-filecoin": "^2.0.1",
+    "prettier": "3.0.0",
+    "viem": "^1.4.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.9",
+    "@playwright/test": "^1.36.1",
+    "@preact/preset-vite": "^2.5.0",
+    "@types/node": "^20.4.4",
+    "vite": "^4.4.7"
+  },
+  "eslintConfig": {
+    "extends": [
+      "../../node_modules/hd-scripts/eslint/preact.js"
+    ],
+    "rules": {
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+      "jsdoc/require-returns": "off",
+      "unicorn/no-null": "off",
+      "no-alert": "off",
+      "no-console": "off"
+    },
+    "parserOptions": {
+      "project": "./tsconfig.json"
+    },
+    "env": {
+      "mocha": true
+    },
+    "ignorePatterns": [
+      "dist"
+    ]
+  },
+  "depcheck": {
+    "specials": [
+      "bin"
+    ],
+    "ignores": [
+      "@types/*",
+      "@acab/reset.css",
+      "water.css",
+      "@preact/signals"
+    ]
+  }
+}

--- a/examples/fil-forwarder-viem/src/main.ts
+++ b/examples/fil-forwarder-viem/src/main.ts
@@ -1,0 +1,134 @@
+import { Token } from 'iso-filecoin/token'
+import { filForwarderMetadata } from 'filsnap-adapter'
+import {
+  createPublicClient,
+  createWalletClient,
+  custom,
+  getContract,
+  http,
+} from 'viem'
+import { filecoinCalibration } from 'viem/chains'
+import * as Address from 'iso-filecoin/address'
+import { PROTOCOL_INDICATOR } from 'iso-filecoin/address'
+
+/**
+ * Transfer FIL from a 0x address to an f1/t1 address.
+ *
+ * @param recipient - The recipient's address.
+ * @param amount - The amount of FIL to transfer.
+ * @returns The FEVM transaction hash of the transfer.
+ */
+async function transfer(
+  recipient: Address.IAddress,
+  amount: Token
+): Promise<`0x${string}`> {
+  if (recipient.protocol !== PROTOCOL_INDICATOR.SECP256K1) {
+    throw new Error('Recipient must be an f1/t1 address')
+  }
+  if (recipient.network !== 'testnet') {
+    throw new Error('Recipient must be a testnet address')
+  }
+
+  // RPC client for requests that needs to be signed
+  const metaMaskClient = createWalletClient({
+    chain: filecoinCalibration,
+    transport: custom(window.ethereum),
+  })
+  // RPC client for requests that that doesn't need signing
+  const publicClient = createPublicClient({
+    chain: filecoinCalibration,
+    transport: http(),
+  })
+
+  // Prompts user to connect MetaMask
+  const [address] = await metaMaskClient.requestAddresses()
+
+  // Initialize the FilForwarder contract
+  const contract = getContract({
+    address: filForwarderMetadata.contractAddress,
+    abi: filForwarderMetadata.abi,
+    publicClient,
+    walletClient: metaMaskClient,
+  })
+
+  // Call the FilForwarder contract's forward method to make the transfer
+  return await contract.write.forward([recipient.toContractDestination()], {
+    value: amount.toBigInt(),
+    account: address,
+  })
+}
+
+/**
+ * Get the explorer URL for a transaction hash.
+ * Assumes FEVM Calibration test net.
+ *
+ * @param txHash - The recipient's address.
+ * @returns The explorer URL for the transaction.
+ */
+function txHashToExplorerUrl(txHash: `0x${string}`): string {
+  return `https://calibration.filfox.info/en/message/${txHash}`
+}
+
+interface FormElements extends HTMLFormControlsCollection {
+  amount: HTMLInputElement
+  recipient: HTMLInputElement
+}
+
+// False positive
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+const form = document.querySelector('#transfer-form')! as HTMLFormElement
+const txLink = document.querySelector('#tx-link')!
+// False positive
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+const submitButton = document.querySelector(
+  '#submit-button'
+)! as HTMLButtonElement
+
+form.addEventListener('submit', (event) => {
+  // Prevent navigation on submit
+  event.preventDefault()
+
+  const elements = form.elements as FormElements
+
+  // Get the amount to transfer from the form and parse it
+  let recipient
+  try {
+    recipient = Address.from(elements.recipient.value)
+  } catch (error) {
+    console.error(error)
+    alert('Invalid recipient')
+    return
+  }
+
+  // Get the amount to transfer from the form and parse it
+  let amount
+  try {
+    amount = Token.fromFIL(elements.amount.value)
+  } catch (error) {
+    console.error(error)
+    alert('Invalid amount')
+    return
+  }
+
+  // Make the transfer
+  submitButton.disabled = true
+  transfer(recipient, amount)
+    .then((txHash) => {
+      // Insert an anchor tag with the transaction hash
+      const txHashAnchor = document.createElement('a')
+      txHashAnchor.href = txHashToExplorerUrl(txHash)
+      txHashAnchor.textContent = 'View transaction in explorer'
+      txHashAnchor.target = '_blank'
+      // Remove the previous transaction hash anchor
+      txLink.innerHTML = ''
+      // Insert the new transaction hash anchor
+      txLink.append(txHashAnchor)
+    })
+    .catch((error) => {
+      console.error(error)
+      alert('Transfer failed')
+    })
+    .finally(() => {
+      submitButton.disabled = false
+    })
+})

--- a/examples/fil-forwarder-viem/src/window-ethereum.d.ts
+++ b/examples/fil-forwarder-viem/src/window-ethereum.d.ts
@@ -1,0 +1,7 @@
+import type { EthereumProvider } from 'viem'
+
+declare global {
+  interface Window {
+    ethereum?: EthereumProvider
+  }
+}

--- a/examples/fil-forwarder-viem/tsconfig.json
+++ b/examples/fil-forwarder-viem/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["ESNext", "DOM"],
+    "emitDeclarationOnly": true,
+    "types": ["vite/client"],
+    "allowImportingTsExtensions": true
+  },
+  "references": [
+    {
+      "path": "../../packages/adapter"
+    }
+  ],
+  "exclude": ["node_modules", "dist", "out"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,9 +99,6 @@ importers:
 
   examples/fil-forwarder-viem:
     dependencies:
-      '@metamask/providers':
-        specifier: ^11.1.0
-        version: 11.1.0
       filsnap-adapter:
         specifier: workspace:^
         version: link:../../packages/adapter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,43 @@ importers:
         specifier: ^4.4.7
         version: 4.4.7(@types/node@20.4.4)
 
+  examples/fil-forwarder-viem:
+    dependencies:
+      '@metamask/providers':
+        specifier: ^11.1.0
+        version: 11.1.0
+      filsnap-adapter:
+        specifier: workspace:^
+        version: link:../../packages/adapter
+      iso-base:
+        specifier: ^1.1.1
+        version: 1.1.1
+      iso-filecoin:
+        specifier: ^2.0.1
+        version: 2.0.1
+      prettier:
+        specifier: 3.0.0
+        version: 3.0.0
+      viem:
+        specifier: ^1.4.1
+        version: 1.4.1(typescript@5.1.6)
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.22.9
+        version: 7.22.9
+      '@playwright/test':
+        specifier: ^1.36.1
+        version: 1.36.1
+      '@preact/preset-vite':
+        specifier: ^2.5.0
+        version: 2.5.0(@babel/core@7.22.9)(preact@10.16.0)(vite@4.4.7)
+      '@types/node':
+        specifier: ^20.4.4
+        version: 20.4.4
+      vite:
+        specifier: ^4.4.7
+        version: 4.4.7(@types/node@20.4.4)
+
   packages/adapter:
     dependencies:
       filsnap:
@@ -7937,7 +7974,6 @@ packages:
     resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}


### PR DESCRIPTION
# Description

This PR adds a TypeScript [Viem](https://viem.sh/) example to make a transfer from a 0x FEVM address in MetaMask to an f1/t1 address using the [FilForwarder](https://github.com/FILCAT/FilForwarder) contract.

The UI is vanilla JS to make it accessible to folks without React experience. The example transfer form looks like this:

<img width="612" alt="Screenshot 2023-07-26 at 19 55 15" src="https://github.com/filecoin-project/filsnap/assets/5764438/2f4f4b3f-a631-4652-ba6a-f56a60c68c4d">

## Link to issue

#20 
