### PR TITLE
Add transaction insight for FilForwarder transactions

### DIFF
--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -1,4 +1,4 @@
 export { FilsnapAdapter } from './snap'
-export { filForwarderMetadata } from './filforwarder-metadata'
 
+export { filForwarderMetadata } from 'filsnap'
 export type { SnapConfig, AccountInfo } from 'filsnap'

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -64,8 +64,9 @@
     "@metamask/key-tree": "^9.0.0",
     "@metamask/snaps-ui": "^0.32.2",
     "iso-base": "^1.1.2",
-    "iso-filecoin": "^2.0.2",
+    "iso-filecoin": "^2.1.0",
     "merge-options": "^3.0.4",
+    "viem": "^1.4.2",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/filecoin-project/filsnap.git"
   },
   "source": {
-    "shasum": "PrxFxKiusGgxcttw9R6UenDIU4vxcM2CFCfrX70fMWM=",
+    "shasum": "X0M8Nk4tUdD2cYqD4SNBF4KajtiGR3lPnAmenDr6ANQ=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",
@@ -23,6 +23,7 @@
       "dapps": true,
       "snaps": true
     },
+    "endowment:transaction-insight": {},
     "snap_dialog": {},
     "snap_getBip44Entropy": [
       {

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/filecoin-project/filsnap.git"
   },
   "source": {
-    "shasum": "X0M8Nk4tUdD2cYqD4SNBF4KajtiGR3lPnAmenDr6ANQ=",
+    "shasum": "OfcugyA6dShGuJZbZAmwbtMOnhKbAuYrPnvX+Al5xf4=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/snap/src/filforwarder-metadata.ts
+++ b/packages/snap/src/filforwarder-metadata.ts
@@ -82,8 +82,8 @@ const contractAddress: `0x${string}` =
   '0x2B3ef6906429b580b7b2080de5CA893BC282c225'
 
 const chainIds = {
-  filecoinMainnet: 314,
-  filecoinCalibrationTestnet: 314_159,
+  filecoinMainnet: 'eip155:13a',
+  filecoinCalibrationTestnet: 'eip155:4cb2f',
 }
 
 // FEVM FilForwarder contract metadata
@@ -92,6 +92,6 @@ export const filForwarderMetadata = {
   abi,
   // The contract address is the same on all chains where the contract is deployed
   contractAddress,
-  // The Ethereum chain ids where the contract is deployed
+  // The CAIP-2 chain ids where the contract is deployed
   chainIds,
 }

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -26,6 +26,10 @@ export type {
   AccountInfo,
 } from './types'
 
+export { filForwarderMetadata } from './filforwarder-metadata'
+
+export { onTransaction } from './transaction-insight'
+
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   try {
     const config = await configFromSnap(snap)

--- a/packages/snap/src/transaction-insight.ts
+++ b/packages/snap/src/transaction-insight.ts
@@ -54,6 +54,9 @@ function contractAddressMatches(transactionTo: string | undefined): boolean {
   )
 }
 
+// Note: currently MetaMask Flask shows the transaction insight tab by default even if we don't display any information
+// in it. This is a bug that the MetaMask team is addressing in this PR:
+// https://github.com/MetaMask/metamask-extension/pull/20267
 export const onTransaction: OnTransactionHandler = async ({
   transaction,
   chainId,

--- a/packages/snap/src/transaction-insight.ts
+++ b/packages/snap/src/transaction-insight.ts
@@ -1,0 +1,118 @@
+import type {
+  OnTransactionHandler,
+  OnTransactionResponse,
+} from '@metamask/snaps-types'
+import { heading, panel, text } from '@metamask/snaps-ui'
+import { fromHex, type Hex } from 'viem'
+import * as Address from 'iso-filecoin/address'
+import { Token } from 'iso-filecoin/token'
+import { filForwarderMetadata } from './filforwarder-metadata'
+import { decodeFunctionData } from 'viem'
+
+/**
+ *
+ * @param message
+ */
+function invalidTransferMessage(message: string): OnTransactionResponse {
+  return {
+    content: panel([heading('Invalid FIL Transfer'), text(message)]),
+  }
+}
+
+/**
+ *
+ * @param chainId
+ */
+function humanReadableNetwork(chainId: string): string {
+  if (chainId === filForwarderMetadata.chainIds.filecoinMainnet) {
+    return 'Filecoin Mainnet'
+  } else if (
+    chainId === filForwarderMetadata.chainIds.filecoinCalibrationTestnet
+  ) {
+    return 'Filecoin Calibration Testnet'
+  } else {
+    throw new Error(`Unknown chain ID: ${chainId}`)
+  }
+}
+
+/**
+ *
+ * @param chainId
+ */
+function chainMatches(chainId: string): boolean {
+  return Object.values(filForwarderMetadata.chainIds).includes(chainId)
+}
+
+/**
+ *
+ * @param transactionTo
+ */
+function contractAddressMatches(transactionTo: string | undefined): boolean {
+  return (
+    transactionTo?.toLowerCase() ===
+    filForwarderMetadata.contractAddress.toLowerCase()
+  )
+}
+
+export const onTransaction: OnTransactionHandler = async ({
+  transaction,
+  chainId,
+}) => {
+  if (
+    !chainMatches(chainId) ||
+    !contractAddressMatches(transaction.to as string | undefined)
+  ) {
+    // Don't show any insights if the transaction is not a FIL transfer.
+    return {
+      content: null,
+    }
+  }
+
+  let transferAmount
+  try {
+    transferAmount = new Token(fromHex(transaction.value as Hex, 'bigint'))
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error)
+    return invalidTransferMessage(
+      `Transfer amount is missing from the transaction.`
+    )
+  }
+
+  let recipient
+  try {
+    const callData = decodeFunctionData({
+      abi: filForwarderMetadata.abi,
+      data: transaction.data as Hex,
+    })
+    if (callData.functionName !== 'forward') {
+      return invalidTransferMessage(`Transaction tries to call wrong method.`)
+    }
+    if (callData.args === undefined || callData.args.length !== 1) {
+      return invalidTransferMessage(`Missing recipient in transaction.`)
+    }
+
+    const isMainNet = chainId === filForwarderMetadata.chainIds.filecoinMainnet
+    recipient = Address.fromContractDestination(
+      callData.args[0] as Hex,
+      isMainNet ? 'mainnet' : 'testnet'
+    )
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error)
+    return invalidTransferMessage(`Transaction recipient is invalid.`)
+  }
+
+  return {
+    content: panel([
+      heading('Transfer FIL'),
+      text(
+        `You are transferring ${transferAmount
+          .toFIL()
+          .toString()} FIL to ${recipient.toString()} on ${humanReadableNetwork(
+          chainId
+        )}`
+      ),
+    ]),
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 7.45.2(react@17.0.0)
       viem:
         specifier: ^1.4.2
-        version: 1.4.2(typescript@5.1.6)
+        version: 1.4.2(typescript@5.1.6)(zod@3.21.4)
       wagmi:
         specifier: ^1.3.9
         version: 1.3.9(react@17.0.0)(typescript@5.1.6)(viem@1.4.2)
@@ -119,7 +119,7 @@ importers:
         version: 3.0.0
       viem:
         specifier: ^1.4.2
-        version: 1.4.2(typescript@5.1.6)
+        version: 1.4.2(typescript@5.1.6)(zod@3.21.4)
     devDependencies:
       '@babel/core':
         specifier: ^7.22.9
@@ -211,11 +211,14 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       iso-filecoin:
-        specifier: ^2.0.2
-        version: 2.0.2
+        specifier: ^2.1.0
+        version: 2.1.0
       merge-options:
         specifier: ^3.0.4
         version: 3.0.4
+      viem:
+        specifier: ^1.4.2
+        version: 1.4.2(typescript@5.1.6)(zod@3.21.4)
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -2824,7 +2827,7 @@ packages:
     resolution: {integrity: sha512-gYw0ki/EAuV1oSyMxpqandHjnthZjYYy+YWpTAzf8BqfXM3ItcZLpjxfg+3+mXW8HIO+3jw6T9iiqEXsqHaMMw==}
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.7.3
-      viem: 1.4.2(typescript@5.1.6)
+      viem: 1.4.2(typescript@5.1.6)(zod@3.21.4)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2848,7 +2851,7 @@ packages:
     resolution: {integrity: sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==}
     dependencies:
       '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.1
       '@scure/base': 1.1.1
     dev: false
 
@@ -2862,7 +2865,7 @@ packages:
   /@scure/bip39@1.2.0:
     resolution: {integrity: sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==}
     dependencies:
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.1
       '@scure/base': 1.1.1
     dev: false
 
@@ -3519,7 +3522,7 @@ packages:
       abitype: 0.8.7(typescript@5.1.6)
       eventemitter3: 4.0.7
       typescript: 5.1.6
-      viem: 1.4.2(typescript@5.1.6)
+      viem: 1.4.2(typescript@5.1.6)(zod@3.21.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil
@@ -3545,7 +3548,7 @@ packages:
       abitype: 0.8.7(typescript@5.1.6)
       eventemitter3: 4.0.7
       typescript: 5.1.6
-      viem: 1.4.2(typescript@5.1.6)
+      viem: 1.4.2(typescript@5.1.6)(zod@3.21.4)
       zustand: 4.3.9(react@17.0.0)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -3952,7 +3955,7 @@ packages:
       typescript: 5.1.6
     dev: false
 
-  /abitype@0.9.3(typescript@5.1.6):
+  /abitype@0.9.3(typescript@5.1.6)(zod@3.21.4):
     resolution: {integrity: sha512-dz4qCQLurx97FQhnb/EIYTk/ldQ+oafEDUqC0VVIeQS1Q48/YWt/9YNfMmp9SLFqN41ktxny3c8aYxHjmFIB/w==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -3964,6 +3967,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.1.6
+      zod: 3.21.4
     dev: false
 
   /acorn-jsx@5.3.2(acorn@8.10.0):
@@ -6864,6 +6868,19 @@ packages:
       zod: 3.21.4
     dev: false
 
+  /iso-filecoin@2.1.0:
+    resolution: {integrity: sha512-E0nA5NqzX3DduYQE5bkT41xIbVHAVrbCVv9P6WuNdJqVRIrR2jLV2bpytBcXnJAFXiJzH3SEnBiRPIRwQFoOww==}
+    dependencies:
+      '@ipld/dag-cbor': 9.0.3
+      '@noble/curves': 1.1.0
+      '@noble/hashes': 1.3.1
+      '@scure/bip32': 1.3.1
+      '@scure/bip39': 1.2.1
+      bignumber.js: 9.1.1
+      iso-base: 1.1.2
+      zod: 3.21.4
+    dev: false
+
   /isomorphic-ws@4.0.1(ws@7.5.9):
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
     peerDependencies:
@@ -9515,7 +9532,7 @@ packages:
       use-sync-external-store: 1.2.0(react@17.0.0)
     dev: false
 
-  /viem@1.4.2(typescript@5.1.6):
+  /viem@1.4.2(typescript@5.1.6)(zod@3.21.4):
     resolution: {integrity: sha512-125E7HoOr5PrL+Iwt8853dQexwRoiPpLwPsrRvlDX94su2xoe7AYqrdfR6N9nmy6vd6mt8eQy8+LWiP3A+1dqw==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -9529,7 +9546,7 @@ packages:
       '@scure/bip32': 1.3.0
       '@scure/bip39': 1.2.0
       '@wagmi/chains': 1.6.0(typescript@5.1.6)
-      abitype: 0.9.3(typescript@5.1.6)
+      abitype: 0.9.3(typescript@5.1.6)(zod@3.21.4)
       isomorphic-ws: 5.0.0(ws@8.12.0)
       typescript: 5.1.6
       ws: 8.12.0
@@ -9605,7 +9622,7 @@ packages:
       react: 17.0.0
       typescript: 5.1.6
       use-sync-external-store: 1.2.0(react@17.0.0)
-      viem: 1.4.2(typescript@5.1.6)
+      viem: 1.4.2(typescript@5.1.6)(zod@3.21.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil


### PR DESCRIPTION
# Description

Add a transaction insight tab for FilForwarder transactions (0x to f1 FIL transfer) to MetaMask:

<img width="500" alt="transaction insight tab example" src="https://github.com/filecoin-project/filsnap/assets/5764438/d9b029bf-5024-4663-80d3-847b02707a9f">

Currently MetaMask Flask will show the empty tab by default for non-FilForwarder transactions as well:

<img width="500" alt="empty transaction insight tab" src="https://github.com/filecoin-project/filsnap/assets/5764438/683eb05e-2dc5-4aae-8186-cfc994f652af">

This is a [bug](https://github.com/MetaMask/metamask-extension/pull/20267) that the MetaMask team is addressing.

We initially wanted to make it dynamically configurable by the user whether the transaction insights is enabled as a workaround for this bug. This is not possible unfortunately, as the empty tab will still show as long as the transaction insight permission is requested by the snap and requesting that permission must be done when the snap is installed.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change that adds functionality)
