### PR TITLE
Adding updated description to snap manifest

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.1",
-  "description": "Connect to Filecoin dapps using Metamask. Manage Filecoin accounts, send FIL to Native and FEVM accounts and enable FEVM transaction insights.",
+  "description": "Enhances MetaMask with native Filecoin address support (e.g. f1 addresses). (Not needed for the Filecoin EVM.)",
   "proposedName": "Filecoin Wallet",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding updated description of Snap to emphasize it's for native Filecoin accounts to disambiguate with FEVM. Related to PR https://github.com/filecoin-project/filsnap/pull/121.