### PR TITLE
Update @metamask/snaps-sdk

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@metamask/key-tree": "^9.0.0",
-    "@metamask/snaps-sdk": "^3.0.1",
+    "@metamask/snaps-sdk": "^4.2.0",
     "iso-base": "^2.0.1",
     "iso-filecoin": "^4.0.3",
     "merge-options": "^3.0.4",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/filecoin-project/filsnap.git"
   },
   "source": {
-    "shasum": "YmjoCze1pMpnlPZBGuE7+b0SjFlhOTOIjBBEgajedmg=",
+    "shasum": "OU2Nq3yPENfUWtpYRoA9B09HCrJhW4T4TjyY90BtDEc=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -217,8 +217,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       '@metamask/snaps-sdk':
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^4.2.0
+        version: 4.2.0
       iso-base:
         specifier: ^2.0.1
         version: 2.0.1
@@ -1220,6 +1220,18 @@ packages:
       '@metamask/utils': 8.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@metamask/json-rpc-engine@8.0.2:
+    resolution: {integrity: sha512-IoQPmql8q7ABLruW7i4EYVHWUbF74yrp63bRuXV5Zf9BQwcn5H9Ww1eLtROYvI1bUXwOiHZ6qT5CWTrDc/t/AA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@metamask/rpc-errors': 6.2.1
+      '@metamask/safe-event-emitter': 3.1.1
+      '@metamask/utils': 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@metamask/json-rpc-middleware-stream@6.0.2:
     resolution: {integrity: sha512-jtyx3PRfc1kqoLpYveIVQNwsxYKefc64/LCl9h9Da1m3nUKEvypbYuXSIwi237qvOjKmNHQKsDOZg6f4uBf62Q==}
@@ -1233,6 +1245,18 @@ packages:
       - supports-color
     dev: true
 
+  /@metamask/json-rpc-middleware-stream@7.0.1:
+    resolution: {integrity: sha512-hsveICXi/56do/mxgwE4IApWwOfZ204iWtSiCcLayEDCLS96X/tqnW1xXvNTrk1l4PtSUHajsyHBY67I89bTIA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@metamask/json-rpc-engine': 8.0.2
+      '@metamask/safe-event-emitter': 3.1.1
+      '@metamask/utils': 8.3.0
+      readable-stream: 3.6.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@metamask/key-tree@9.0.0:
     resolution: {integrity: sha512-Fma7twGR7PK0QLby0ZCI2q4VDiSlZM0iIUYvmExDtiS6TIGQBu4br0rMWgfgMBz+arFFw8FriQxRrNBv4hb8SA==}
     engines: {node: '>=16.0.0'}
@@ -1245,6 +1269,19 @@ packages:
       '@scure/base': 1.1.5
     transitivePeerDependencies:
       - supports-color
+
+  /@metamask/key-tree@9.1.1:
+    resolution: {integrity: sha512-Z/KEbNlNvLeaBIjw+ibtC8gfLAm7X152JPcLo2KJgw8wMxKjwq/OjkI3XIqn7hFRA2HWCm3MWJPcABQsXWPQcQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@metamask/scure-bip39': 2.1.1
+      '@metamask/utils': 8.3.0
+      '@noble/curves': 1.3.0
+      '@noble/hashes': 1.3.3
+      '@scure/base': 1.1.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@metamask/number-to-bn@1.7.1:
     resolution: {integrity: sha512-qCN+Au4amvcVii2LdOJNndYhdmk5Lk9tlStJhKpZ8tGeYQDJTghqYXJuSUVPHvfl6FUfKY1i1Or2j2EbnEerSQ==}
@@ -1300,6 +1337,7 @@ packages:
       webextension-polyfill: 0.10.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@metamask/providers@15.0.0:
     resolution: {integrity: sha512-FXvL1NQNl6I7fMOJTfQYcBlBZ33vSlm6w80cMpmn8sJh0Lb7wcBpe02UwBsNlARnI+Qsr26XeDs6WHUHQh8CuA==}
@@ -1321,6 +1359,26 @@ packages:
       - supports-color
     dev: true
 
+  /@metamask/providers@16.1.0:
+    resolution: {integrity: sha512-znVCvux30+3SaUwcUGaSf+pUckzT5ukPRpcBmy+muBLC0yaWnBcvDqGfcsw6CBIenUdFrVoAFa8B6jsuCY/a+g==}
+    engines: {node: ^18.18 || >=20}
+    dependencies:
+      '@metamask/json-rpc-engine': 8.0.2
+      '@metamask/json-rpc-middleware-stream': 7.0.1
+      '@metamask/object-multiplex': 2.0.0
+      '@metamask/rpc-errors': 6.2.1
+      '@metamask/safe-event-emitter': 3.1.1
+      '@metamask/utils': 8.3.0
+      detect-browser: 5.3.0
+      extension-port-stream: 3.0.0
+      fast-deep-equal: 3.1.3
+      is-stream: 2.0.1
+      readable-stream: 3.6.2
+      webextension-polyfill: 0.10.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@metamask/rpc-errors@6.2.1:
     resolution: {integrity: sha512-VTgWkjWLzb0nupkFl1duQi9Mk8TGT9rsdnQg6DeRrYEFxtFOh0IF8nAwxM/4GWqDl6uIB06lqUBgUrAVWl62Bw==}
     engines: {node: '>=16.0.0'}
@@ -1336,6 +1394,11 @@ packages:
 
   /@metamask/safe-event-emitter@3.0.0:
     resolution: {integrity: sha512-j6Z47VOmVyGMlnKXZmL0fyvWfEYtKWCA9yGZkU3FCsGZUT5lHGmvaV9JA5F2Y+010y7+ROtR3WMXIkvl/nVzqQ==}
+    engines: {node: '>=12.0.0'}
+    dev: true
+
+  /@metamask/safe-event-emitter@3.1.1:
+    resolution: {integrity: sha512-ihb3B0T/wJm1eUuArYP4lCTSEoZsClHhuWyfo/kMX3m/odpqNcPfsz5O2A3NT7dXCAgWPGDQGPqygCpgeniKMw==}
     engines: {node: '>=12.0.0'}
 
   /@metamask/scure-bip39@2.1.1:
@@ -1399,6 +1462,21 @@ packages:
       superstruct: 1.0.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@metamask/snaps-sdk@4.2.0:
+    resolution: {integrity: sha512-LQlq12CH+BYJPhflL9AFX9FihKxljfW86WFBP43JRlJwSkzWYLAFhTg0bzuv5AMOQI+LAXMhNABuSHTS954bFA==}
+    engines: {node: ^18.16 || >=20}
+    dependencies:
+      '@metamask/key-tree': 9.1.1
+      '@metamask/providers': 16.1.0
+      '@metamask/rpc-errors': 6.2.1
+      '@metamask/utils': 8.3.0
+      fast-xml-parser: 4.3.5
+      superstruct: 1.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@metamask/snaps-utils@6.1.0(@babel/runtime@7.24.0)(@metamask/approval-controller@5.1.3):
     resolution: {integrity: sha512-N8aeqN2DGcqEdb90q1ps3gHLOG7X5M9/1m6Fi/F7CBrRxQGXXL2aAZotRXg3CJzu5bChFimHwiDe8dLrjcidtw==}
@@ -1698,6 +1776,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     dev: false
     bundledDependencies:
       - napi-wasm
@@ -6404,11 +6483,12 @@ packages:
     engines: {node: ^16.20 || ^18.16 || >=20}
     dependencies:
       '@metamask/json-rpc-engine': 7.3.3
-      '@metamask/safe-event-emitter': 3.0.0
+      '@metamask/safe-event-emitter': 3.1.1
       '@metamask/utils': 8.3.0
       readable-stream: 3.6.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /json-rpc-random-id@1.0.1:
     resolution: {integrity: sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA==}
@@ -7027,6 +7107,10 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
     dev: true
+
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+    dev: false
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}


### PR DESCRIPTION
# Description

Updates `@metamask/snaps-sdk` from version `3.0.1` to `4.2.0`. The old version exports a bunch of TypeScript declarations that should have been kept internal. For example, `*.svg` imports are typed to `string`, which is very inconvenient if your project does not have that convention and causes VS Code to show type errors across the board.

## Type of change

- [x] Refactor (non-breaking change that updates existing functionality)
