### PR TITLE
fix: MacOs typescript error on running locally resolved

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -55,6 +55,24 @@
   },
   "wireit": {
     "build": {
+      "dependencies": ["build:types", "build:snap"]
+    },
+    "build:types": {
+      "command": "pnpm exec tsc --noEmitOnError false",
+      "files": [
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "tsconfig.json"
+      ],
+      "output": [
+        "dist/src/**/*.d.ts",
+        "dist/src/**/*.js",
+        "dist/test/**/*.d.ts",
+        "dist/test/**/*.js"
+      ],
+      "clean": false
+    },
+    "build:snap": {
       "command": "mm-snap build",
       "files": [
         "src/**/*.ts",
@@ -77,9 +95,7 @@
     },
     "test": {
       "command": "playwright test",
-      "dependencies": [
-        "build"
-      ]
+      "dependencies": ["build"]
     },
     "serve": {
       "command": "mm-snap serve",
@@ -107,6 +123,8 @@
   "devDependencies": {
     "@metamask/snaps-cli": "8.2.0",
     "@playwright/test": "^1.54.2",
+    "@types/react": "19.1.10",
+    "@types/react-dom": "19.1.7",
     "@types/react": "19.1.10",
     "@types/react-dom": "19.1.7",
     "metamask-testing-tools": "^2.2.6",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/filecoin-project/filsnap.git"
   },
   "source": {
-    "shasum": "z7zf69ZZsXa3fl9ypIXhsYnED5Cq8pB6uVrqG3GF1H0=",
+    "shasum": "Jxey/TnElGhvPoSJ+IJhaedYI4wLM20N0snbQzROHYw=",
     "location": {
       "npm": {
         "filePath": "dist/snap.js",

--- a/packages/snap/tsconfig.json
+++ b/packages/snap/tsconfig.json
@@ -3,11 +3,13 @@
   "compilerOptions": {
     "outDir": "dist",
     "jsx": "react-jsxdev",
-    "jsxImportSource": "@metamask/snaps-sdk"
+    "jsxImportSource": "@metamask/snaps-sdk",
+    "types": ["@metamask/snaps-sdk"],         
+    "lib": ["es2022", "dom"],                                      
   },
   "include": ["src", "test", "snap.manifest.json"],
   "exclude": ["node_modules", "dist", "out"],
-  "typedocOptions": {
+   "typedocOptions": {
     "entryPointStrategy": "resolve",
     "entryPoints": ["src/index.tsx"],
     "includeVersion": true,


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Link to issue https://github.com/filecoin-project/filsnap/issues/399

Please add a link to any relevant issues/tickets
https://github.com/filecoin-project/filsnap/issues/399

## Type of change:
- package.json for snap package was updated to resolve the build time typescript error

- react and react-dom was added to fix error related to not having react and react-dom but using react/types
[_These were added because **packages/snap** is also rendering React UI and without these local errors were appearing_]

- to fix issues associated with types clash between React’s JSX types and the Snaps JSX, tsconfig has been updated
[_The Snap UI (Box, Header, Section, etc.) is from @metamask/snaps-sdk/jsx, which defines its own JSX.Element (“SnapElement”). Because @types/react is in scope, TypeScript is trying to validate those components as React elements (ReactNode) and rejects them → TS2786. Fixed by isolating React types out of the snap package and telling TS to use the Snaps JSX runtime._]

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change that fixes an issue)

## Screenshots:
<img width="1280" height="954" alt="image" src="https://github.com/user-attachments/assets/4156984d-ca69-4f69-b0d5-69ceefe5694c" />

<img width="1512" height="905" alt="image" src="https://github.com/user-attachments/assets/5cc68f0f-0597-4365-913e-62297a9969ac" />


